### PR TITLE
Support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "combell/combell-api",
     "description": "Combell public API for customers with direct activation",
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "guzzlehttp/guzzle": "^6.5|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Currently v3 of this project states PHP version 7.4 as a dependency, this fork by @esseremmerik adds 8.x support.

Can this merged?