### PR TITLE
fix(deps): require guzzlehttp/guzzle ^7.12.1 for CVE-2026-55568

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Combell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Combell public API for customers with direct activation",
     "require": {
         "php": "^7.4|^8.0",
-        "guzzlehttp/guzzle": "^6.5|^7.0"
+        "guzzlehttp/guzzle": "^7.12.1"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "combell/combell-api",
     "description": "Combell public API for customers with direct activation",
+    "license": "MIT",
     "require": {
         "php": "^7.4|^8.0",
         "guzzlehttp/guzzle": "^7.12.1"


### PR DESCRIPTION
## Description
<!-- What does this MR do and why? -->
Bump the minimum `guzzlehttp/guzzle` version to `^7.12.1` to remediate
CVE-2026-55568 / GHSA-wpwq-4j6v-78m3 (silent HTTPS-proxy downgrade to
cleartext). The advisory affects all versions below 7.12.1 and there is
no patched 6.x release, so support for Guzzle 6.x is dropped.

Because dropping a supported dependency major is a breaking change for
consumers, this is released as the new **v4** major line (per SemVer and
the existing v1/v2/v3 branch convention).

Also adds an MIT `LICENSE` file and declares `"license": "MIT"` in
`composer.json`.